### PR TITLE
Add plugin manifest

### DIFF
--- a/manifest
+++ b/manifest
@@ -1,3 +1,3 @@
-# this manifest contains the name of every currently implemented plugin. it can be pulled via https://github.com/opencost/opencost-plugins/blob/main/manifest to get an up to date list of current plugins.
+# this manifest contains the name of every currently implemented plugin. it can be pulled via https://github.com/opencost/opencost-plugins/raw/main/manifest to get an up to date list of current plugins.
 
 datadog

--- a/manifest
+++ b/manifest
@@ -1,0 +1,3 @@
+# this manifest contains the name of every currently implemented plugin. it can be pulled via https://github.com/opencost/opencost-plugins/blob/main/manifest to get an up to date list of current plugins.
+
+datadog


### PR DESCRIPTION
## What does this PR change?
* Adds a manifest containing a list of all currently enable plugins.

## Does this PR relate to any other PRs?
* Nope.

## How will this PR impact users?
* The FE (or potentially the BE) will be able to query for all available plugins, allowing for an improved user experience.

## Does this PR address any GitHub or Zendesk issues?
* Nope.

## How was this PR tested?
* File downloads don't need a whole lot of testing, these days.

## Does this PR require changes to documentation?
* Not as of yet.