### PR TITLE
Disable DataDog queries for future dates

### DIFF
--- a/datadog/cmd/main/main.go
+++ b/datadog/cmd/main/main.go
@@ -73,6 +73,12 @@ func (d *DatadogCostSource) GetCustomCosts(req *pb.CustomCostRequest) []*pb.Cust
 	}
 
 	for _, target := range targets {
+		// DataDog gets mad if we ask them to tell the future
+		if target.Start().After(time.Now().UTC()) {
+			log.Debugf("skipping future window %v", target)
+			continue
+		}
+
 		log.Debugf("fetching DD costs for window %v", target)
 		result := d.getDDCostsForWindow(target, listPricing)
 		results = append(results, result)

--- a/datadog/tests/datadog_test.go
+++ b/datadog/tests/datadog_test.go
@@ -70,6 +70,24 @@ func TestDDCostRetrievalListCost(t *testing.T) {
 	}
 }
 
+func TestFuturism(t *testing.T) {
+	// query for the future
+	windowStart := time.Now().UTC().Truncate(time.Hour).Add(time.Hour)
+	windowEnd := windowStart.Add(time.Hour)
+
+	response := getResponse(t, windowStart, windowEnd, time.Hour)
+
+	// when we query for data in the future, we expect to get back no data AND no errors
+	if len(response) > 0 {
+		t.Fatalf("got non-empty response")
+	}
+	for _, resp := range response {
+		if len(resp.Errors) > 0 {
+			t.Fatalf("got errors in response: %v", resp.Errors)
+		}
+	}
+}
+
 func TestDDCostRetrievalBilledCost(t *testing.T) {
 	// query for qty 2 of 1 hour windows
 	windowStart := time.Date(2024, 3, 16, 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## What does this PR change?
* Updates the DataDog plugin to disallow API calls with dates in the future, preventing 400 responses.

## Does this PR relate to any other PRs?
* Nope.

## How will this PR impact users?
* Users will no longer see abundant "400 Bad Request" error logs.

## Does this PR address any GitHub or Zendesk issues?
* Nope.

## How was this PR tested?
* Unit tests.

## Does this PR require changes to documentation?
* Nope.