### PR TITLE
[Datadog] fix price parsing API

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ commonenv := "CGO_ENABLED=0"
 
 version := `./tools/image-tag`
 commit := `git rev-parse --short HEAD`
-pluginPaths := `find ./pkg/plugins -type f -iname "go.mod" -print0 | xargs -0 dirname | xargs basename | tr ' ' ','`
+pluginPaths := `find ./pkg/plugins -type f -iname "go.mod" -print0 | xargs -0 dirname | xargs -I{} basename {} | tr ' ' ',' | tr '\n' ','`
 default:
     just --list
 

--- a/pkg/plugins/datadog/cmd/main/main.go
+++ b/pkg/plugins/datadog/cmd/main/main.go
@@ -677,7 +677,7 @@ func scrapeDatadogPrices(url string) (*datadogplugin.PricingInformation, error) 
 		}
 		response.Body.Close()
 		res := datadogplugin.DatadogProJSON{}
-		r := regexp.MustCompile(`var productDetailData = \s*(.*?)\s*;`)
+		r := regexp.MustCompile(`var productDetailData = \s*(.*?)\s*};`)
 		log.Tracef("got response: %s", string(b))
 		matches := r.FindAllStringSubmatch(string(b), -1)
 		if len(matches) != 1 {
@@ -688,7 +688,8 @@ func scrapeDatadogPrices(url string) (*datadogplugin.PricingInformation, error) 
 		}
 
 		log.Tracef("matches[0][1]:" + matches[0][1])
-		err = json.Unmarshal([]byte(matches[0][1]), &res)
+		// add back in the closing curly brace that was used to pattern match
+		err = json.Unmarshal([]byte(matches[0][1]+"}"), &res)
 		if err != nil {
 			errTry = err
 			log.Errorf("failed to read pricing page body: %v", err)


### PR DESCRIPTION
## What does this PR change?
* fixes and issue where the price scraper was not correctly getting prices from AWS 

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* 

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 